### PR TITLE
Fix firebase config appId

### DIFF
--- a/src/services/Firebase.ts
+++ b/src/services/Firebase.ts
@@ -3,8 +3,14 @@ import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
 import { getAuth, GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { getDatabase } from "firebase/database";
+import { Platform } from "react-native";
 
 // https://firebase.google.com/docs/web/setup#available-libraries
+
+const APP_ID =
+  Platform.OS === "ios"
+    ? process.env.EXPO_PUBLIC_FIREBASE_IOS_APP_ID
+    : process.env.EXPO_PUBLIC_FIREBASE_ANDROID_APP_ID;
 
 interface FirebaseConfig {
   apiKey: any;
@@ -24,7 +30,7 @@ const firebaseConfig: FirebaseConfig = {
   projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
   storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+  appId: APP_ID,
   measurementId: process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 


### PR DESCRIPTION
This pull request fixes the `appId` of the firebase config file. The `appId` is now set based on the platform (iOS or Android) using the `EXPO_PUBLIC_FIREBASE_IOS_APP_ID` and `EXPO_PUBLIC_FIREBASE_ANDROID_APP_ID` environment variables.