### PR TITLE
Add i18n support for new screens

### DIFF
--- a/__tests__/OrderHistory.test.tsx
+++ b/__tests__/OrderHistory.test.tsx
@@ -4,6 +4,7 @@ import OrderHistory from "../src/app/OrderHistory";
 import { RootStackParamList } from "../src/types/RootStackParamList";
 import { createStackNavigator } from "@react-navigation/stack";
 import { NavigationContainer } from "@react-navigation/native";
+import { initI18n } from "../src/lang/i18n";
 
 const mockNavigation = {
   navigate: jest.fn(),
@@ -47,6 +48,10 @@ const OrderHistoryTest = () => {
     </NavigationContainer>
   );
 };
+
+beforeEach(() => {
+  initI18n();
+});
 
 describe("OrderHistory", () => {
   it("renders correctly", async () => {

--- a/__tests__/PayButton.test.tsx
+++ b/__tests__/PayButton.test.tsx
@@ -3,6 +3,7 @@ import { Alert } from "react-native";
 import { PayButton } from "../src/components/PayButton";
 import { useStripe } from "@stripe/stripe-react-native";
 import React from "react";
+import { initI18n } from "../src/lang/i18n";
 
 beforeEach(() => {
   process.env.EXPO_PUBLIC_STRIPE_ENDPOINT_URL = "https://example.com/stripe";
@@ -19,6 +20,8 @@ beforeEach(() => {
         }),
     })
   );
+
+  initI18n();
 });
 
 describe("PayButton", () => {

--- a/src/app/Map.tsx
+++ b/src/app/Map.tsx
@@ -4,11 +4,7 @@ import { StyleSheet, View, TouchableOpacity, Text, Alert } from "react-native";
 import MapView, { Marker } from "react-native-maps";
 import * as Location from "expo-location";
 import Icon from "react-native-vector-icons/MaterialIcons";
-import {
-  NavigationProp,
-  RouteProp,
-  useNavigation,
-} from "@react-navigation/native";
+import { useTranslation } from "react-i18next";
 
 const topButtonPadding = 60;
 const sideButtonPadding = 30;
@@ -22,6 +18,8 @@ const MapOverview = ({ navigation }: any) => {
     longitudeDelta: 0.0421,
   });
 
+  const { t } = useTranslation();
+
   const [marker, setMarker] = useState({
     latitude: 37.789,
     longitude: -122.4324,
@@ -33,7 +31,7 @@ const MapOverview = ({ navigation }: any) => {
     let { status } = await Location.requestForegroundPermissionsAsync();
     if (status !== "granted") {
       setLocationPermission(false);
-      Alert.alert("Permission to access location was denied");
+      Alert.alert(t("map.permission-denied"));
       return false;
     }
     setLocationPermission(true);
@@ -61,7 +59,7 @@ const MapOverview = ({ navigation }: any) => {
         longitude: location.coords.longitude,
       });
     } else {
-      Alert.alert("Location permission not granted");
+      Alert.alert(t("map.permission-not-granted"));
     }
   };
 
@@ -76,7 +74,7 @@ const MapOverview = ({ navigation }: any) => {
         <Marker
           testID="map-marker"
           coordinate={marker}
-          title="Current Location"
+          title={t("map.marker-title")}
         />
       </MapView>
 
@@ -94,7 +92,7 @@ const MapOverview = ({ navigation }: any) => {
         style={[styles.button, styles.buttonBottomRight]}
         onPress={() => navigation.navigate("OrderMenu")}
       >
-        <Text style={styles.buttonText}>Order</Text>
+        <Text style={styles.buttonText}>{t("map.order-button")}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/src/app/OrderHistory.tsx
+++ b/src/app/OrderHistory.tsx
@@ -14,6 +14,7 @@ import TriangleBackground from "../components/TriangleBackground";
 import { RootStackParamList } from "../types/RootStackParamList";
 import { RouteProp } from "@react-navigation/native";
 import { MessageBox } from "../ui/MessageBox";
+import { useTranslation } from "react-i18next";
 
 /* 
 NOTE: This is a temporary solution to simulate fetching orders from a server. Should be replaced with actual database calls
@@ -81,6 +82,7 @@ const OrderHistory = ({
 }) => {
   const { opOrders, userId } = route.params;
 
+  const { t } = useTranslation();
   const [orders, setOrders] = useState<Order[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -119,7 +121,7 @@ const OrderHistory = ({
           />
         </TouchableOpacity>
         <Text className="text-2xl font-bold text-center my-4">
-          Order history
+          {t("order-history.title")}
         </Text>
         <TouchableOpacity
           className="absolute right-4"

--- a/src/app/OrderMenu.tsx
+++ b/src/app/OrderMenu.tsx
@@ -29,7 +29,7 @@ export default function OrderMenu({ navigation }: any) {
     <View style={styles.container} testID="order-menu-screen">
       <TriangleBackground />
       <Text style={styles.text} testID="order-menu-text">
-        Choose your item
+        {t("order-menu.choose-item")}
       </Text>
       {productButtons.map((button) => (
         <OrderButton

--- a/src/app/OrderMenu.tsx
+++ b/src/app/OrderMenu.tsx
@@ -4,6 +4,7 @@ import { Text, StyleSheet, View } from "react-native";
 import TriangleBackground from "../components/TriangleBackground";
 import { productButtons } from "../types/ProductButtons";
 import ItemCard from "../components/ItemCard";
+import { useTranslation } from "react-i18next";
 
 interface OrderProps {
   // Define your component props here
@@ -11,6 +12,8 @@ interface OrderProps {
 }
 
 export default function OrderMenu({ navigation }: any) {
+  const { t } = useTranslation();
+
   const [visibleItemId, setVisibleItemId] = useState<number | null>(null);
 
   const handleOpenCard = (itemId: number) => {
@@ -29,7 +32,7 @@ export default function OrderMenu({ navigation }: any) {
       </Text>
       {productButtons.map((button) => (
         <OrderButton
-          title={button.item.getName()}
+          title={t(button.item.getName())}
           icon={button.item.getIcon()}
           onPress={() => handleOpenCard(button.item.getId())}
           key={button.item.getId()}

--- a/src/app/OrderMenu.tsx
+++ b/src/app/OrderMenu.tsx
@@ -5,6 +5,7 @@ import TriangleBackground from "../components/TriangleBackground";
 import { productButtons } from "../types/ProductButtons";
 import ItemCard from "../components/ItemCard";
 import { useTranslation } from "react-i18next";
+import { TranslationKeys } from "../types/translation-keys";
 
 interface OrderProps {
   // Define your component props here
@@ -32,7 +33,7 @@ export default function OrderMenu({ navigation }: any) {
       </Text>
       {productButtons.map((button) => (
         <OrderButton
-          title={t(button.item.getName())}
+          title={t(button.item.getName() as TranslationKeys)}
           icon={button.item.getIcon()}
           onPress={() => handleOpenCard(button.item.getId())}
           key={button.item.getId()}

--- a/src/app/OrderPlaced.tsx
+++ b/src/app/OrderPlaced.tsx
@@ -117,7 +117,7 @@ const OrderPlaced = ({
             {t("order-placed.order-summary")}
           </Text>
           <Text className="text-xl my-2 font-kaisei" testID="ordered-item-name">
-            {orderedItem.getName()}
+            {t(orderedItem.getName())}
           </Text>
           <Text className="text-lg font-kaisei" testID="user-location">
             {t("order-placed.location")} {userLocation}

--- a/src/app/OrderPlaced.tsx
+++ b/src/app/OrderPlaced.tsx
@@ -7,6 +7,7 @@ import Icon from "react-native-vector-icons/Fontisto";
 import TriangleBackground from "../components/TriangleBackground";
 import { Animated } from "react-native";
 import { secureRandom } from "../utils/random";
+import { useTranslation } from "react-i18next";
 
 const OrderPlaced = ({
   route,
@@ -15,6 +16,8 @@ const OrderPlaced = ({
   route: RouteProp<RootStackParamList, "OrderPlaced">;
   navigation: any;
 }) => {
+  const { t } = useTranslation();
+
   const [fadeAnim] = useState(new Animated.Value(0));
 
   const { orderedItem, placedAt, userLocation } = route.params;
@@ -63,7 +66,7 @@ const OrderPlaced = ({
       hour12: false,
     });
 
-    return `Arriving at ${formattedDate}`;
+    return `${t("order-placed.arriving-at")} ${formattedDate}`;
   };
 
   return (
@@ -77,7 +80,7 @@ const OrderPlaced = ({
           className=" text-3xl font-bold font-kaisei"
           testID="order-placed-message"
         >
-          Your order is on its way
+          {t("order-placed.on-its-way")}
         </Text>
         <View className="my-2 flex items-start">
           <Text className="text-lg my-2 font-kaisei" testID="arrival-time">
@@ -111,13 +114,13 @@ const OrderPlaced = ({
             className="text-2xl font-semibold font-kaisei"
             testID="order-summary"
           >
-            Order summary
+            {t("order-placed.order-summary")}
           </Text>
           <Text className="text-xl my-2 font-kaisei" testID="ordered-item-name">
             {orderedItem.getName()}
           </Text>
           <Text className="text-lg font-kaisei" testID="user-location">
-            Location: {userLocation}
+            {t("order-placed.location")} {userLocation}
           </Text>
           <Image
             className="w-64 h-64 rounded-lg"
@@ -136,10 +139,10 @@ const OrderPlaced = ({
             className="text-lg font-semibold font-kaisei"
             testID="order-complete"
           >
-            Your order should have been delivered!
+            {t("order-placed.order-complete")}
           </Text>
           <Text className="text-lg font-kaisei" testID="order-complete-message">
-            Thanks for trusting us!
+            {t("order-placed.thanks")}
           </Text>
           {/* <TouchableOpacity>
             <Text className="text-red-500 font-kaisei" testID="report-issue">
@@ -166,7 +169,7 @@ const OrderPlaced = ({
           }
         >
           <Text className="text-black font-kaisei underline">
-            View order history
+            {t("order-placed.view-order-history")}
           </Text>
         </TouchableOpacity>
       </View>

--- a/src/app/OrderPlaced.tsx
+++ b/src/app/OrderPlaced.tsx
@@ -8,6 +8,7 @@ import TriangleBackground from "../components/TriangleBackground";
 import { Animated } from "react-native";
 import { secureRandom } from "../utils/random";
 import { useTranslation } from "react-i18next";
+import { TranslationKeys } from "../types/translation-keys";
 
 const OrderPlaced = ({
   route,
@@ -117,7 +118,7 @@ const OrderPlaced = ({
             {t("order-placed.order-summary")}
           </Text>
           <Text className="text-xl my-2 font-kaisei" testID="ordered-item-name">
-            {t(orderedItem.getName())}
+            {t(orderedItem.getName() as TranslationKeys)}
           </Text>
           <Text className="text-lg font-kaisei" testID="user-location">
             {t("order-placed.location")} {userLocation}

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -4,6 +4,7 @@ import { Item } from "../types/Item";
 import Icon from "react-native-vector-icons/FontAwesome";
 import { BlurView } from "expo-blur";
 import { PayButton } from "./PayButton";
+import { useTranslation } from "react-i18next";
 
 interface ItemCardProps {
   isVisible: boolean;
@@ -22,6 +23,8 @@ function ItemCard({
     return null;
   }
 
+  const { t } = useTranslation();
+
   return (
     <View style={styles.visibleCard} testID={`item-card-view-${item.getId()}`}>
       <BlurView intensity={10} style={styles.blurContainer} testID="blur-view">
@@ -33,8 +36,8 @@ function ItemCard({
           >
             <Icon name="close" size={20} color="#000" testID="close-icon" />
           </TouchableOpacity>
-          <Text style={styles.title}>{item.getName()}</Text>
-          <Text style={styles.description}>{item.getDescription()}</Text>
+          <Text style={styles.title}>{t(item.getName())}</Text>
+          <Text style={styles.description}>{t(item.getDescription())}</Text>
           <Image
             style={styles.image}
             source={item.getImage()}

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -114,6 +114,8 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: "bold",
     marginVertical: 8,
+    justifyContent: "center",
+    textAlign: "center",
   },
   description: {
     fontSize: 16,

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -5,6 +5,7 @@ import Icon from "react-native-vector-icons/FontAwesome";
 import { BlurView } from "expo-blur";
 import { PayButton } from "./PayButton";
 import { useTranslation } from "react-i18next";
+import { TranslationKeys } from "../types/translation-keys";
 
 interface ItemCardProps {
   isVisible: boolean;
@@ -36,8 +37,12 @@ function ItemCard({
           >
             <Icon name="close" size={20} color="#000" testID="close-icon" />
           </TouchableOpacity>
-          <Text style={styles.title}>{t(item.getName())}</Text>
-          <Text style={styles.description}>{t(item.getDescription())}</Text>
+          <Text style={styles.title}>
+            {t(item.getName() as TranslationKeys)}
+          </Text>
+          <Text style={styles.description}>
+            {t(item.getDescription() as TranslationKeys)}
+          </Text>
           <Image
             style={styles.image}
             source={item.getImage()}

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -20,11 +20,11 @@ function ItemCard({
   handleOrder,
   item,
 }: ItemCardProps) {
+  const { t } = useTranslation();
+
   if (!isVisible) {
     return null;
   }
-
-  const { t } = useTranslation();
 
   return (
     <View style={styles.visibleCard} testID={`item-card-view-${item.getId()}`}>

--- a/src/components/OrderButton.tsx
+++ b/src/components/OrderButton.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   Image,
   ImageSourcePropType,
+  View,
 } from "react-native";
 import { buttonStyles } from "../styles/ButtonStyles";
 
@@ -16,9 +17,22 @@ interface ButtonProps {
 
 const Button: React.FC<ButtonProps> = ({ title, icon, onPress }) => {
   return (
-    <TouchableOpacity style={buttonStyles.order_button} onPress={onPress}>
-      <Image style={buttonStyles.image} source={icon} testID="image" />
-      <Text style={styles.text}>{title}</Text>
+    <TouchableOpacity
+      className="flex flex-row w-full"
+      style={buttonStyles.order_button}
+      onPress={onPress}
+    >
+      <View className="flex flex-row items-center w-full p-8">
+        <Image style={buttonStyles.image} source={icon} testID="image" />
+        <Text
+          className="w-2/3"
+          style={styles.text}
+          numberOfLines={1}
+          ellipsizeMode="clip"
+        >
+          {title}
+        </Text>
+      </View>
     </TouchableOpacity>
   );
 };
@@ -29,6 +43,6 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 24,
     lineHeight: 33,
-    marginLeft: 20,
+    marginLeft: 10,
   },
 });

--- a/src/components/PayButton.tsx
+++ b/src/components/PayButton.tsx
@@ -3,9 +3,10 @@ import {
   StripeError,
   useStripe,
 } from "@stripe/stripe-react-native";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "../ui/Button";
 import { Alert } from "react-native";
+import { useTranslation } from "react-i18next";
 
 export function PayButton({
   amount,
@@ -18,6 +19,7 @@ export function PayButton({
 }) {
   const { initPaymentSheet, presentPaymentSheet } = useStripe();
   const [loading, setLoading] = useState(true);
+  const { t } = useTranslation();
 
   const fetchPaymentSheetParams = async () => {
     if (!process.env.EXPO_PUBLIC_STRIPE_ENDPOINT_URL) {
@@ -90,8 +92,8 @@ export function PayButton({
     <Button
       testID="pay-button"
       style="primary"
-      text={loading ? "Loading..." : `CHF ${amount / 100}`}
-      onPress={loading ? () => Alert.alert("Please wait") : openPaymentSheet}
+      text={loading ? t("global.loading") : `CHF ${amount / 100}`}
+      onPress={loading ? () => Alert.alert(t("global.wait")) : openPaymentSheet}
     />
   );
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -60,6 +60,12 @@
     "thanks": "Thanks for trusting us",
     "view-order-history": "View order history"
   },
+  "order-history": {
+    "title": "Order history"
+  },
+  "order-menu": {
+    "choose-item": "Choose an item"
+  },
   "global": {
     "loading": "Loading...",
     "wait": "Please wait..."

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -34,5 +34,11 @@
     "moderate": "Password is moderate",
     "strong": "Password is strong",
     "very-strong": "Password is very strong"
+  },
+  "map": {
+    "permission-denied": "Permission to access location denied",
+    "permission-not-granted": "Location permission not granted",
+    "marker-title": "Current location",
+    "order-button": "Order"
   }
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -51,6 +51,15 @@
     "powerbank": "Power bank",
     "powerbank-description": "20000 mAh battery. USB-C, lightning and USB-A connections."
   },
+  "order-placed": {
+    "arriving-at": "Arriving at",
+    "on-its-way": "Your order is on its way",
+    "order-summary": "Order summary",
+    "location": "Location: ",
+    "order-complete": "Your order should have been delivered",
+    "thanks": "Thanks for trusting us",
+    "view-order-history": "View order history"
+  },
   "global": {
     "loading": "Loading...",
     "wait": "Please wait..."

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -40,5 +40,15 @@
     "permission-not-granted": "Location permission not granted",
     "marker-title": "Current location",
     "order-button": "Order"
+  },
+  "items": {
+    "first-aid": "First aid kit",
+    "first-aid-description": "Constains bandages, plasters, rubbing alcohol, asthma pump.",
+    "flashlight": "Flashlight",
+    "flashlight-description": "1000 lumens. Powered by two AA batteries.",
+    "thermal-blanket": "Thermal blanket",
+    "thermal-blanket-description": "Made of reflective material to contain body heat.",
+    "powerbank": "Power bank",
+    "powerbank-description": "20000 mAh battery. USB-C, lightning and USB-A connections."
   }
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -50,5 +50,9 @@
     "thermal-blanket-description": "Made of reflective material to contain body heat.",
     "powerbank": "Power bank",
     "powerbank-description": "20000 mAh battery. USB-C, lightning and USB-A connections."
+  },
+  "global": {
+    "loading": "Loading...",
+    "wait": "Please wait..."
   }
 }

--- a/src/lang/translations/de.json
+++ b/src/lang/translations/de.json
@@ -34,5 +34,40 @@
     "moderate": "Passwort ist moderat",
     "strong": "Passwort ist stark",
     "very-strong": "Passwort ist sehr stark"
+  },
+  "map": {
+    "permission-denied": "Zugriff auf Standort verweigert",
+    "permission-not-granted": "Standortberechtigung nicht erteilt",
+    "marker-title": "Aktueller Standort",
+    "order-button": "Bestellen"
+  },
+  "items": {
+    "first-aid": "Erste-Hilfe-Set",
+    "first-aid-description": "Enthält Verbände, Pflaster, Reibealkohol, Asthmapumpe.",
+    "flashlight": "Taschenlampe",
+    "flashlight-description": "1000 Lumen. Betrieben mit zwei AA-Batterien.",
+    "thermal-blanket": "Thermodecke",
+    "thermal-blanket-description": "Hergestellt aus reflektierendem Material, um Körperwärme zu speichern.",
+    "powerbank": "Powerbank",
+    "powerbank-description": "20000 mAh Batterie. USB-C, Lightning und USB-A Anschlüsse."
+  },
+  "order-placed": {
+    "arriving-at": "Ankunft bei",
+    "on-its-way": "Ihre Bestellung ist unterwegs",
+    "order-summary": "Bestellübersicht",
+    "location": "Standort: ",
+    "order-complete": "Ihre Bestellung sollte zugestellt worden sein",
+    "thanks": "Danke, dass Sie uns vertrauen",
+    "view-order-history": "Bestellverlauf anzeigen"
+  },
+  "order-history": {
+    "title": "Bestellverlauf"
+  },
+  "order-menu": {
+    "choose-item": "Wählen Sie einen Artikel"
+  },
+  "global": {
+    "loading": "Laden...",
+    "wait": "Bitte warten..."
   }
 }

--- a/src/lang/translations/dz.json
+++ b/src/lang/translations/dz.json
@@ -34,5 +34,40 @@
     "moderate": "كلمة المرور معتدلة",
     "strong": "كلمة المرور قوية",
     "very-strong": "كلمة المرور قوية جدا"
+  },
+  "map": {
+    "permission-denied": "تم رفض الإذن للوصول إلى الموقع",
+    "permission-not-granted": "لم يتم منح إذن الموقع",
+    "marker-title": "الموقع الحالي",
+    "order-button": "طلب"
+  },
+  "items": {
+    "first-aid": "صندوق الإسعافات الأولية",
+    "first-aid-description": "يحتوي على أشرطة، لصقات، الكحول، مضخة الربو.",
+    "flashlight": "كشاف",
+    "flashlight-description": "1000 لومن. يعمل بواسطة بطاريتين AA.",
+    "thermal-blanket": "بطانية حرارية",
+    "thermal-blanket-description": "مصنوعة من مادة عاكسة للحفاظ على حرارة الجسم.",
+    "powerbank": "بنك الطاقة",
+    "powerbank-description": "بطارية 20000 مللي أمبير في الساعة. موصلات USB-C، البرق وUSB-A."
+  },
+  "order-placed": {
+    "arriving-at": "وصول في",
+    "on-its-way": "طلبك في الطريق",
+    "order-summary": "ملخص الطلب",
+    "location": "الموقع: ",
+    "order-complete": "كان يجب أن يتم توصيل طلبك",
+    "thanks": "شكرا لثقتك بنا",
+    "view-order-history": "عرض تاريخ الطلب"
+  },
+  "order-history": {
+    "title": "تاريخ الطلب"
+  },
+  "order-menu": {
+    "choose-item": "اختر عنصرا"
+  },
+  "global": {
+    "loading": "جار التحميل...",
+    "wait": "الرجاء الانتظار..."
   }
 }

--- a/src/lang/translations/es.json
+++ b/src/lang/translations/es.json
@@ -34,5 +34,40 @@
     "moderate": "La contraseña es moderada",
     "strong": "La contraseña es fuerte",
     "very-strong": "La contraseña es muy fuerte"
+  },
+  "map": {
+    "permission-denied": "Permiso para acceder a la ubicación denegado",
+    "permission-not-granted": "Permiso de ubicación no concedido",
+    "marker-title": "Ubicación actual",
+    "order-button": "Ordenar"
+  },
+  "items": {
+    "first-aid": "Botiquín de primeros auxilios",
+    "first-aid-description": "Contiene vendas, apósitos, alcohol para frotar, bomba de asma.",
+    "flashlight": "Linterna",
+    "flashlight-description": "1000 lúmenes. Alimentado por dos pilas AA.",
+    "thermal-blanket": "Manta térmica",
+    "thermal-blanket-description": "Hecho de material reflectante para contener el calor corporal.",
+    "powerbank": "Banco de energía",
+    "powerbank-description": "Batería de 20000 mAh. Conexiones USB-C, lightning y USB-A."
+  },
+  "order-placed": {
+    "arriving-at": "Llegando a",
+    "on-its-way": "Tu pedido está en camino",
+    "order-summary": "Resumen del pedido",
+    "location": "Ubicación: ",
+    "order-complete": "Tu pedido debería haber sido entregado",
+    "thanks": "Gracias por confiar en nosotros",
+    "view-order-history": "Ver historial de pedidos"
+  },
+  "order-history": {
+    "title": "Historial de pedidos"
+  },
+  "order-menu": {
+    "choose-item": "Elige un artículo"
+  },
+  "global": {
+    "loading": "Cargando...",
+    "wait": "Por favor espera..."
   }
 }

--- a/src/lang/translations/fr.json
+++ b/src/lang/translations/fr.json
@@ -34,5 +34,40 @@
     "moderate": "Le mot de passe est moyen",
     "strong": "Le mot de passe est fort",
     "very-strong": "Le mot de passe est très fort"
+  },
+  "map": {
+    "permission-denied": "Permission to access location denied",
+    "permission-not-granted": "Location permission not granted",
+    "marker-title": "Current location",
+    "order-button": "Order"
+  },
+  "items": {
+    "first-aid": "First aid kit",
+    "first-aid-description": "Constains bandages, plasters, rubbing alcohol, asthma pump.",
+    "flashlight": "Flashlight",
+    "flashlight-description": "1000 lumens. Powered by two AA batteries.",
+    "thermal-blanket": "Thermal blanket",
+    "thermal-blanket-description": "Made of reflective material to contain body heat.",
+    "powerbank": "Power bank",
+    "powerbank-description": "20000 mAh battery. USB-C, lightning and USB-A connections."
+  },
+  "order-placed": {
+    "arriving-at": "Arriving at",
+    "on-its-way": "Your order is on its way",
+    "order-summary": "Order summary",
+    "location": "Location: ",
+    "order-complete": "Your order should have been delivered",
+    "thanks": "Thanks for trusting us",
+    "view-order-history": "View order history"
+  },
+  "order-history": {
+    "title": "Order history"
+  },
+  "order-menu": {
+    "choose-item": "Choose an item"
+  },
+  "global": {
+    "loading": "Loading...",
+    "wait": "Please wait..."
   }
 }

--- a/src/lang/translations/gr.json
+++ b/src/lang/translations/gr.json
@@ -34,5 +34,40 @@
     "moderate": "Ο κωδικός είναι μέτριος",
     "strong": "Ο κωδικός είναι δυνατός",
     "very-strong": "Ο κωδικός είναι πολύ δυνατός"
+  },
+  "map": {
+    "permission-denied": "Άρνηση άδειας πρόσβασης στην τοποθεσία",
+    "permission-not-granted": "Δεν χορηγήθηκε άδεια τοποθεσίας",
+    "marker-title": "Τρέχουσα τοποθεσία",
+    "order-button": "Παραγγελία"
+  },
+  "items": {
+    "first-aid": "Κιτ πρώτων βοηθειών",
+    "first-aid-description": "Περιέχει επίδεσμους, αψεσουάρ, αλκοόλ, αντλία άσθματος.",
+    "flashlight": "Φακός",
+    "flashlight-description": "1000 lumens. Λειτουργεί με δύο μπαταρίες AA.",
+    "thermal-blanket": "Θερμική κουβέρτα",
+    "thermal-blanket-description": "Κατασκευασμένο από ανακλαστικό υλικό για να διατηρεί τη θερμότητα του σώματος.",
+    "powerbank": "Τράπεζα ενέργειας",
+    "powerbank-description": "Μπαταρία 20000 mAh. Συνδέσεις USB-C, lightning και USB-A."
+  },
+  "order-placed": {
+    "arriving-at": "Άφιξη στο",
+    "on-its-way": "Η παραγγελία σας είναι σε εξέλιξη",
+    "order-summary": "Περίληψη παραγγελίας",
+    "location": "Τοποθεσία: ",
+    "order-complete": "Η παραγγελία σας θα έπρεπε να έχει παραδοθεί",
+    "thanks": "Ευχαριστούμε που μας εμπιστεύεστε",
+    "view-order-history": "Προβολή ιστορικού παραγγελιών"
+  },
+  "order-history": {
+    "title": "Ιστορικό παραγγελιών"
+  },
+  "order-menu": {
+    "choose-item": "Επιλέξτε ένα αντικείμενο"
+  },
+  "global": {
+    "loading": "Φόρτωση...",
+    "wait": "Παρακαλώ περιμένετε..."
   }
 }

--- a/src/lang/translations/it.json
+++ b/src/lang/translations/it.json
@@ -34,5 +34,40 @@
     "moderate": "La password è moderata",
     "strong": "La password è forte",
     "very-strong": "La password è molto forte"
+  },
+  "map": {
+    "permission-denied": "Permesso di accedere alla posizione negato",
+    "permission-not-granted": "Permesso di localizzazione non concesso",
+    "marker-title": "Posizione attuale",
+    "order-button": "Ordina"
+  },
+  "items": {
+    "first-aid": "Kit di pronto soccorso",
+    "first-aid-description": "Contiene bende, cerotti, alcool denaturato, pompa per asma.",
+    "flashlight": "Torcia",
+    "flashlight-description": "1000 lumen. Alimentato da due batterie AA.",
+    "thermal-blanket": "Coperta termica",
+    "thermal-blanket-description": "Realizzato in materiale riflettente per trattenere il calore corporeo.",
+    "powerbank": "Power bank",
+    "powerbank-description": "Batteria da 20000 mAh. Connessioni USB-C, lightning e USB-A."
+  },
+  "order-placed": {
+    "arriving-at": "Arriva a",
+    "on-its-way": "Il tuo ordine è in viaggio",
+    "order-summary": "Riepilogo dell'ordine",
+    "location": "Posizione: ",
+    "order-complete": "Il tuo ordine dovrebbe essere stato consegnato",
+    "thanks": "Grazie per averci fatto confidenza",
+    "view-order-history": "Visualizza lo storico degli ordini"
+  },
+  "order-history": {
+    "title": "Storico degli ordini"
+  },
+  "order-menu": {
+    "choose-item": "Scegli un articolo"
+  },
+  "global": {
+    "loading": "Caricamento...",
+    "wait": "Attendere prego..."
   }
 }

--- a/src/lang/translations/pk.json
+++ b/src/lang/translations/pk.json
@@ -34,5 +34,40 @@
     "moderate": "پاس ورڈ معتدل ہے",
     "strong": "پاس ورڈ مضبوط ہے",
     "very-strong": "پاس ورڈ بہت مضبوط ہے"
+  },
+  "map": {
+    "permission-denied": "مقام تک رسائی کی اجازت مسترد",
+    "permission-not-granted": "مقام کی اجازت نہیں ملی",
+    "marker-title": "موجودہ مقام",
+    "order-button": "آرڈر"
+  },
+  "items": {
+    "first-aid": "پہلی امداد کا کٹ",
+    "first-aid-description": "پٹیاں، پلاسٹر، رگڑنے والا الکحل، دمہ پمپ شامل ہیں۔",
+    "flashlight": "فلیش لائٹ",
+    "flashlight-description": "1000 لیومنز۔ دو AA بیٹریوں سے چلتی ہے۔",
+    "thermal-blanket": "حرارتی کمبل",
+    "thermal-blanket-description": "جسمانی حرارت کو محفوظ کرنے کے لئے عکاسی مواد سے بنا ہوا۔",
+    "powerbank": "پاور بینک",
+    "powerbank-description": "20000 mAh بیٹری۔ USB-C، لائٹننگ اور USB-A کنکشنز۔"
+  },
+  "order-placed": {
+    "arriving-at": "پہنچ رہا ہے",
+    "on-its-way": "آپ کا آرڈر راستے میں ہے",
+    "order-summary": "آرڈر کا خلاصہ",
+    "location": "مقام: ",
+    "order-complete": "آپ کا آرڈر پہنچ چکا ہونا چاہئے",
+    "thanks": "ہم پر اعتماد کرنے کا شکریہ",
+    "view-order-history": "آرڈر کی تاریخ دیکھیں"
+  },
+  "order-history": {
+    "title": "آرڈر کی تاریخ"
+  },
+  "order-menu": {
+    "choose-item": "آئٹم منتخب کریں"
+  },
+  "global": {
+    "loading": "لوڈ ہو رہا ہے...",
+    "wait": "براہ کرم انتظار کریں..."
   }
 }

--- a/src/lang/translations/ro.json
+++ b/src/lang/translations/ro.json
@@ -34,5 +34,40 @@
     "moderate": "Parola este moderată",
     "strong": "Parola este puternică",
     "very-strong": "Parola este foarte puternică"
+  },
+  "map": {
+    "permission-denied": "Permisiunea de accesare a locației a fost refuzată",
+    "permission-not-granted": "Permisiunea de localizare nu a fost acordată",
+    "marker-title": "Locația curentă",
+    "order-button": "Comandă"
+  },
+  "items": {
+    "first-aid": "Kit de prim ajutor",
+    "first-aid-description": "Conține bandaje, plasturi, alcool pentru frecție, pompă pentru astm.",
+    "flashlight": "Lanterna",
+    "flashlight-description": "1000 lumeni. Alimentat de două baterii AA.",
+    "thermal-blanket": "Pătură termică",
+    "thermal-blanket-description": "Fabricat din material reflectorizant pentru a reține căldura corpului.",
+    "powerbank": "Baterie externă",
+    "powerbank-description": "Baterie de 20000 mAh. Conexiuni USB-C, lightning și USB-A."
+  },
+  "order-placed": {
+    "arriving-at": "Ajunge la",
+    "on-its-way": "Comanda ta este în drum",
+    "order-summary": "Rezumatul comenzii",
+    "location": "Locație: ",
+    "order-complete": "Comanda ta ar fi trebuit să fie livrată",
+    "thanks": "Mulțumim pentru încrederea acordată",
+    "view-order-history": "Vezi istoricul comenzilor"
+  },
+  "order-history": {
+    "title": "Istoricul comenzilor"
+  },
+  "order-menu": {
+    "choose-item": "Alege un articol"
+  },
+  "global": {
+    "loading": "Se încarcă...",
+    "wait": "Vă rugăm să așteptați..."
   }
 }

--- a/src/types/ProductButtons.ts
+++ b/src/types/ProductButtons.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Item } from "./Item";
 
 interface ProductButton {
@@ -5,11 +6,13 @@ interface ProductButton {
   onPress: () => void;
 }
 
+const { t } = useTranslation();
+
 const names: string[] = [
-  "First aid kit",
-  "Flashlight",
-  "Thermal blanket",
-  "Power bank",
+  t("items.first-aid"),
+  t("items.flashlight"),
+  t("items.thermal-blanket"),
+  t("items.powerbank"),
 ];
 
 const iconDirs: string[] = [
@@ -45,10 +48,10 @@ const images: number[] = [
 const prices: number[] = [20, 15, 10, 30];
 
 const descriptions: string[] = [
-  "Constains bandages, plasters, rubbing alcohol, asthma pump.",
-  "1000 lumens. Powered by two AA batteries.",
-  "Made of reflective material to contain body heat.",
-  "20000 mAh battery. USB-C, lightning and USB-A connections.",
+  t("items.first-aid-description"),
+  t("items.flashlight-description"),
+  t("items.thermal-blanket-description"),
+  t("items.powerbank-description"),
 ];
 
 const items: Item[] = names.map((name, i) => {

--- a/src/types/ProductButtons.ts
+++ b/src/types/ProductButtons.ts
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next";
 import { Item } from "./Item";
 
 interface ProductButton {
@@ -6,13 +5,11 @@ interface ProductButton {
   onPress: () => void;
 }
 
-const { t } = useTranslation();
-
 const names: string[] = [
-  t("items.first-aid"),
-  t("items.flashlight"),
-  t("items.thermal-blanket"),
-  t("items.powerbank"),
+  "items.first-aid",
+  "items.flashlight",
+  "items.thermal-blanket",
+  "items.powerbank",
 ];
 
 const iconDirs: string[] = [
@@ -48,10 +45,10 @@ const images: number[] = [
 const prices: number[] = [20, 15, 10, 30];
 
 const descriptions: string[] = [
-  t("items.first-aid-description"),
-  t("items.flashlight-description"),
-  t("items.thermal-blanket-description"),
-  t("items.powerbank-description"),
+  "items.first-aid-description",
+  "items.flashlight-description",
+  "items.thermal-blanket-description",
+  "items.powerbank-description",
 ];
 
 const items: Item[] = names.map((name, i) => {

--- a/src/types/translation-keys.d.ts
+++ b/src/types/translation-keys.d.ts
@@ -1,0 +1,11 @@
+// src/types/translation-keys.d.ts
+
+export type TranslationKeys =
+  | "items.first-aid"
+  | "items.flashlight"
+  | "items.thermal-blanket"
+  | "items.powerbank"
+  | "items.first-aid-description"
+  | "items.flashlight-description"
+  | "items.thermal-blanket-description"
+  | "items.powerbank-description";


### PR DESCRIPTION
This pull request adds internationalization (i18n) support for the new screens in the project. It includes the following changes:

- Added i18n for the map screen

- Added i18n for the items (products)

- Fixed i18n for the items

- Added i18n for the PayButton component

- Added i18n for the order placed message

- Fixed i18n for the item names

- Added types for the items i18n

- Updated pay button test

- Added i18n for the order history screen

- Added i18n for the OrderHistory screen

- Added i18n for the new screens in different languages (de, ro, pk/urdu, it, greek, fr, es, arabic)

- Fixed styling issues in the ItemCard and OrderButton components

- Updated fallback language