### PR TITLE
Improved error hanling and fixed triangle displacement - PendingOrders & OrderHistory

### DIFF
--- a/src/app/OrderHistory.tsx
+++ b/src/app/OrderHistory.tsx
@@ -105,7 +105,6 @@ const OrderHistory = ({
   };
   return (
     <View className="mt-16" testID="order-history-screen">
-      <TriangleBackground color="#A0D1E4" />
       <View className="flex-row items-center justify-center">
         <TouchableOpacity className="absolute left-4" testID="menu-button">
           <Image
@@ -128,32 +127,36 @@ const OrderHistory = ({
           />
         </TouchableOpacity>
       </View>
-
-      <TriangleBackground color="#A0D1E4" />
-      {error ? (
+      {
+        error && (
+          <TriangleBackground color="#A0D1E4" bottom={-125} />
+        ) /* These are some magic numbers that I figured out by trial and error*/
+      }
+      {!error && <TriangleBackground color="#A0D1E4" bottom={-200} />}
+      {error && (
         <MessageBox
           message={error.message}
           style="error"
           onClose={() => setError(null)}
           testID="error-box"
         />
-      ) : (
-        <FlatList
-          className="mt-4 min-h-full"
-          data={orders}
-          // if I am an operator, I want to see the user's location name
-          // if I am user, I want to see where I ordered from
-          renderItem={({ item }) => (
-            <OrderCard order={item} opBool={!historyOp} />
-          )}
-          keyExtractor={(item) => item.getId()}
-          onEndReached={fetchOrders}
-          onEndReachedThreshold={0.1}
-          refreshing={refreshing}
-          onRefresh={fetchOrders}
-          testID="orderHistoryFlatList"
-        />
       )}
+
+      <FlatList
+        className="mt-4 min-h-full"
+        data={orders}
+        // if I am an operator, I want to see the user's location name
+        // if I am user, I want to see where I ordered from
+        renderItem={({ item }) => (
+          <OrderCard order={item} opBool={!historyOp} />
+        )}
+        keyExtractor={(item) => item.getId()}
+        onEndReached={fetchOrders}
+        onEndReachedThreshold={0.1}
+        refreshing={refreshing}
+        onRefresh={fetchOrders}
+        testID="orderHistoryFlatList"
+      />
     </View>
   );
 };

--- a/src/app/PendingOrders.tsx
+++ b/src/app/PendingOrders.tsx
@@ -132,34 +132,39 @@ const PendingOrders = ({ navigation }: any) => {
         </TouchableOpacity>
       </View>
 
-      <TriangleBackground color="#A0D1E4" />
-      {error ? (
+      {
+        error && (
+          <TriangleBackground color="#A0D1E4" bottom={-125} />
+        ) /* These are some magic numbers that I figured out by trial and error*/
+      }
+      {!error && <TriangleBackground color="#A0D1E4" bottom={-200} />}
+      {error && (
         <MessageBox
           message={error.message}
           style="error"
           onClose={() => setError(null)}
           testID="error-box"
         />
-      ) : (
-        <FlatList
-          data={orders}
-          renderItem={({ item }) => (
-            <OrderCard
-              order={item}
-              onClick={() => handleOpenCard(item)}
-              opBool={false}
-              testId={`order-card-${item.getId()}`}
-              onClickTestId={`order-card-${item.getId()}-button`}
-            /> // opBool is false because we want to show the user's location name
-          )}
-          keyExtractor={(item) => item.getId()}
-          onEndReached={fetchOrders}
-          onEndReachedThreshold={0.1}
-          refreshing={refreshing}
-          onRefresh={fetchOrders}
-          testID="order-list"
-        />
       )}
+      <FlatList
+        data={orders}
+        renderItem={({ item }) => (
+          <OrderCard
+            order={item}
+            onClick={() => handleOpenCard(item)}
+            opBool={false}
+            testId={`order-card-${item.getId()}`}
+            onClickTestId={`order-card-${item.getId()}-button`}
+          /> // opBool is false because we want to show the user's location name
+        )}
+        keyExtractor={(item) => item.getId()}
+        onEndReached={fetchOrders}
+        onEndReachedThreshold={0.1}
+        refreshing={refreshing}
+        onRefresh={fetchOrders}
+        testID="order-list"
+      />
+
       {selectedOrder && (
         <Modal animationType="none" transparent={true} visible={true}>
           <View className="flex-1 justify-center items-center bg-opacity-100">


### PR DESCRIPTION
With the previous implementation if an error was being thrown, the FlatList would not be displayed, and as a result we could not refresh the screen in any way shape or form without exiting and re-opening it. Now the FlatList will still be displayed which will allow the user to call fetchOrders again the usual way (at the top of page, then swiping down). 
The TriangleBackground would also be offset to a weird spot in the case that an error was being displayed, so I now display TriangleBackground's with different "bottom" values depending on if "error" is defined or not. Now the TriangleBackground is always at the same spot.

Note: Currently it'll display a "Failed to fetch from database." error and state "No valid query field provided" in console. This is because some changes that were made w.r.t. how things are stored in FIrestore, however this will be fixed in Zak's upcoming PR. Then it'll display "**No orders have been made yet. Go place some orders :)**" in the case of no orders, or the actual OrderCards