### PR TITLE
Added temporary SignOut button at OrderMenu & Fixed FlatList display for when scrolling

### DIFF
--- a/src/app/order/OrderHistory.tsx
+++ b/src/app/order/OrderHistory.tsx
@@ -208,7 +208,7 @@ const OrderHistory = ({
       )}
 
       <FlatList
-        className="mt-4 min-h-full"
+        className="mt-4 min-h-full mb-6"
         data={orderListFiltered}
         // if I am an operator, I want to see the user's location name
         // if I am user, I want to see where I ordered from

--- a/src/app/order/OrderMenu.tsx
+++ b/src/app/order/OrderMenu.tsx
@@ -11,6 +11,7 @@ import { Order, OrderLocation } from "../../types/Order";
 import { auth } from "../../services/Firebase";
 import { RouteProp } from "@react-navigation/native";
 import { RootStackParamList } from "../../types/RootStackParamList";
+import { signOut } from "firebase/auth";
 
 export default function OrderMenu({
   route,
@@ -26,7 +27,17 @@ export default function OrderMenu({
   const { t } = useTranslation();
 
   const [visibleItemId, setVisibleItemId] = useState<number | null>(null);
-
+  const handleSignOut = async () => {
+    try {
+      await signOut(auth);
+      // Navigate to login screen or perform other actions after sign out
+      navigation.navigate("Login");
+    } catch (error) {
+      console.error("Error signing out: ", error);
+    } finally {
+      console.log("Signout handled");
+    }
+  };
   const handleOpenCard = (itemId: number) => {
     setVisibleItemId(itemId);
   };
@@ -79,6 +90,11 @@ export default function OrderMenu({
       <Button
         title="Go to Settings"
         onPress={() => navigation.navigate("Settings")}
+        color="#007AFF"
+      />
+      <Button
+        title="Sign out"
+        onPress={() => handleSignOut()}
         color="#007AFF"
       />
     </View>

--- a/src/app/order/PendingOrders.tsx
+++ b/src/app/order/PendingOrders.tsx
@@ -216,7 +216,7 @@ const PendingOrders = ({ navigation }: any) => {
         />
       )}
       <FlatList
-        className="mt-4 min-h-full"
+        className="mt-4 min-h-full mb-6"
         data={orderListFiltered}
         renderItem={({ item }) => (
           <OrderCard


### PR DESCRIPTION
- Added signout button as even when clearing the expo cache it was still remembering my account, and I wanted to login to an account with a bunch orders to test the scrolling
- When displaying a lot of OrderCards, the user would be incapable of seeing the last one as it would be cut off, fixed by *margin-bottom* propery