### PR TITLE
Brought back persistent authentication + Fixed navigation to OrderHistory

### DIFF
--- a/__tests__/OrderHistory.test.tsx
+++ b/__tests__/OrderHistory.test.tsx
@@ -52,6 +52,16 @@ jest.mock("../src/services/FirestoreManager", () => {
   };
 });
 
+jest.mock("../src/services/Firebase", () => {
+  return {
+    auth: {
+      currentUser: {
+        uid: "user1",
+      },
+    },
+  };
+});
+
 type OrderHistoryStack = {
   OrderHistory: RootStackParamList["OrderHistory"];
 };
@@ -66,7 +76,6 @@ const OrderHistoryTest = () => {
           name="OrderHistory"
           initialParams={{
             historyOp: false,
-            userId: "user1",
           }}
         >
           {(props) => <OrderHistory {...props} />}
@@ -110,7 +119,6 @@ describe("OrderHistory", () => {
       name: "OrderHistory",
       params: {
         historyOp: false,
-        userId: "user1",
       },
     };
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,48 +17,8 @@ initI18n();
 
 function App() {
   const [userInfo, setUserInfo] = useState<User | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState<"Login" | "UserDrawer">("Login");
-  const checkLocalUser = async () => {
-    try {
-      const user = await AsyncStorage.getItem("@user");
-      if (user) {
-        setUserInfo(JSON.parse(user));
-        setIsLoggedIn("UserDrawer");
-      } else {
-        setIsLoggedIn("Login");
-      }
-    } catch (e) {
-      alert(e);
-    } finally {
-      //setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    checkLocalUser();
-    const unsub = onAuthStateChanged(auth, async (user) => {
-      if (user) {
-        setUserInfo(user);
-        setIsLoggedIn("UserDrawer");
-        try {
-          await AsyncStorage.setItem("@user", JSON.stringify(user));
-        } catch (e) {
-          alert(e);
-        }
-      } else {
-        setUserInfo(null);
-        setIsLoggedIn("Login");
-        try {
-          await AsyncStorage.removeItem("@user");
-        } catch (e) {
-          alert(e);
-        }
-      }
-    });
-
-    return unsub;
-  }, []);
 
   const stripePublishableKey = process.env.STRIPE_PUBLISHABLE_KEY || "";
 

--- a/src/app/AppStack.tsx
+++ b/src/app/AppStack.tsx
@@ -105,10 +105,7 @@ function UserDrawer<UserDrawerProps>(user: UserDrawerProps) {
         })}
       >
         {(props: any) => (
-          <OrderHistory
-            {...props}
-            route={{ params: { historyOp: false, user } }}
-          />
+          <OrderHistory {...props} route={{ params: { historyOp: false } }} />
         )}
       </Drawer.Screen>
     </Drawer.Navigator>

--- a/src/app/order/OrderHistory.tsx
+++ b/src/app/order/OrderHistory.tsx
@@ -19,6 +19,7 @@ import FirestoreManager from "../../services/FirestoreManager";
 import { useTranslation } from "react-i18next";
 import { formatDate } from "../../components/cards/OrderCard";
 import { Picker } from "@react-native-picker/picker";
+import { auth } from "../../services/Firebase";
 /* 
 NOTE: This is a temporary solution to simulate fetching orders from a server. Should be replaced with actual database calls
 */
@@ -69,13 +70,14 @@ const OrderHistory = ({
   navigation: any;
 }) => {
   const firestoreManager = new FirestoreManager();
-  const { historyOp, userId } = route.params;
+  const { historyOp } = route.params;
   const [searchText, setSearchText] = useState("");
   const { t } = useTranslation();
   const [orders, setOrders] = useState<Order[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [sortingOption, setSortingOption] = useState("descendingDate");
+  const uid = auth.currentUser?.uid;
 
   useEffect(() => {
     fetchOrders();
@@ -85,7 +87,8 @@ const OrderHistory = ({
     setRefreshing(true);
     try {
       const field = historyOp ? "operatorId" : "userId";
-      let newOrders = await firestoreManager.queryOrder(field, userId);
+      console.log("fetching orders for user: " + uid);
+      let newOrders = await firestoreManager.queryOrder(field, uid || "");
       if (newOrders === null) {
         setError(new Error("Failed to fetch from database."));
       } else if (newOrders.length === 0) {
@@ -93,9 +96,6 @@ const OrderHistory = ({
           new Error("No orders have been made yet. Go place some orders :)")
         );
       } else {
-        /*const sortedOrders = newOrders.sort(
-          (a, b) => b.getOrderDate().getTime() - a.getOrderDate().getTime()
-        );*/
         setOrders(newOrders);
         setError(null); // Clear the error if the fetch is successful
       }

--- a/src/app/order/OrderPlaced.tsx
+++ b/src/app/order/OrderPlaced.tsx
@@ -196,7 +196,6 @@ const OrderPlaced = ({
           onPress={() =>
             navigation.navigate("OrderHistory", {
               historyOp: false,
-              userId: auth.currentUser ? auth.currentUser.uid : "",
             })
           }
         >

--- a/src/types/RootStackParamList.ts
+++ b/src/types/RootStackParamList.ts
@@ -17,7 +17,6 @@ export type RootStackParamList = {
   };
   OrderHistory: {
     historyOp: boolean;
-    userId: string;
   };
   PendingOrders: undefined; // Added for PendingOrders
   OperatorDrawer: undefined;


### PR DESCRIPTION
- With the merge of Drawer Navigation persistent authentication feature was undone, but now its back :)
- With the merge of Drawer Navigation some issues were encountered where the user ID being passed to OrderHistory was null. Fixed by removing userID as navigation parameter from OrderHistory & fetching it from auth.currentUser?.uid

KNOWN ISSUES: 
- "X" go back button on OrderHistory (probably PendingOrders too) does NOT work
- There is an overlap of a "Go back" arrow on the top left, and the "Burger" drawer button
I messaged Eduardo on Telegram, and I believe he will be fixing these in his next PR