### PR TITLE
Persistent Auth Fix + OrderHistory/PendingOrders FlatList Fix + Updated PendingOrders Accept Interface + KnAIght UI improvements + Map UI improvements + Auto delete stale orders from Firestore

### DIFF
--- a/__tests__/Knaight.test.tsx
+++ b/__tests__/Knaight.test.tsx
@@ -11,8 +11,8 @@ describe("ChatScreen", () => {
     const messagesList = getByTestId("messages-list");
     expect(messagesList).toBeDefined();
 
-    const input = getByPlaceholderText("Type a message...");
-    const sendButton = getByText("Send");
+    const input = getByTestId("message-input");
+    const sendButton = getByTestId("send-button");
 
     fireEvent.changeText(input, "Hello");
     fireEvent.press(sendButton);

--- a/__tests__/PendingOrders.test.tsx
+++ b/__tests__/PendingOrders.test.tsx
@@ -57,15 +57,25 @@ jest.mock("../src/services/FirestoreManager", () => {
   };
 });
 
-jest.mock("expo-location", () => {
-  const originalModule = jest.requireActual("expo-location");
-  return {
-    __esModule: true,
-    ...originalModule,
-    requestForegroundPermissionsAsync: jest.fn(),
-    watchPositionAsync: jest.fn(),
-  };
-});
+jest.mock("expo-location", () => ({
+  requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({
+    status: "granted",
+  }),
+  watchPositionAsync: jest.fn().mockImplementation((options, callback) => {
+    callback({
+      coords: {
+        latitude: 37.789,
+        longitude: -122.4324,
+      },
+    });
+    return {
+      remove: jest.fn(),
+    };
+  }),
+  Accuracy: {
+    BestForNavigation: 5,
+  },
+}));
 
 describe("PendingOrders Component", () => {
   it("renders without crashing", () => {

--- a/__tests__/PendingOrders.test.tsx
+++ b/__tests__/PendingOrders.test.tsx
@@ -4,6 +4,7 @@ import PendingOrders from "../src/app/order/PendingOrders";
 import { Order, OrderStatus } from "../src/types/Order";
 import { Item } from "../src/types/Item";
 import FirestoreManager from "../src/services/FirestoreManager";
+import * as Location from "expo-location";
 
 jest.mock("../src/services/FirestoreManager", () => {
   return {
@@ -53,6 +54,16 @@ jest.mock("../src/services/FirestoreManager", () => {
           ),
       };
     }),
+  };
+});
+
+jest.mock("expo-location", () => {
+  const originalModule = jest.requireActual("expo-location");
+  return {
+    __esModule: true,
+    ...originalModule,
+    requestForegroundPermissionsAsync: jest.fn(),
+    watchPositionAsync: jest.fn(),
   };
 });
 

--- a/src/app/order/OrderHistory.tsx
+++ b/src/app/order/OrderHistory.tsx
@@ -92,9 +92,13 @@ const OrderHistory = ({
       if (newOrders === null) {
         setError(new Error("Failed to fetch from database."));
       } else if (newOrders.length === 0) {
-        setError(
-          new Error("No orders have been made yet. Go place some orders :)")
-        );
+        historyOp
+          ? setError(
+              new Error("You have not accepted any orders yet as an operator.")
+            )
+          : setError(
+              new Error("No orders have been made yet. Go place some orders :)")
+            );
       } else {
         setOrders(newOrders);
         setError(null); // Clear the error if the fetch is successful
@@ -186,12 +190,16 @@ const OrderHistory = ({
       )}
 
       <FlatList
-        className="mt-4 max-h-[90%]"
+        className="mt-4 max-h-[90%] min-h-[90%]"
         data={orderListFiltered}
         // if I am an operator, I want to see the user's location name
         // if I am user, I want to see where I ordered from
         renderItem={({ item }) => (
-          <OrderCard order={item} opBool={!historyOp} />
+          <OrderCard
+            order={item}
+            opBool={!historyOp}
+            //onClick={() => console.log(item.getId())}
+          />
         )}
         keyExtractor={(item) => item.getId()}
         onEndReached={fetchOrders}

--- a/src/app/order/OrderHistory.tsx
+++ b/src/app/order/OrderHistory.tsx
@@ -186,7 +186,7 @@ const OrderHistory = ({
       )}
 
       <FlatList
-        className="mt-4 min-h-full mb-6"
+        className="mt-4 max-h-[90%]"
         data={orderListFiltered}
         // if I am an operator, I want to see the user's location name
         // if I am user, I want to see where I ordered from

--- a/src/app/order/OrderMenu.tsx
+++ b/src/app/order/OrderMenu.tsx
@@ -44,6 +44,7 @@ export default function OrderMenu({
     if (user != null) {
       const order = new Order(user.uid, item, userLocation);
       await order.locSearch(); // This is to call the Nominatim API to define the user location name
+      console.log("Order placed: ", order);
       firestoreManager.writeData("orders", order);
       navigation.navigate("OrderPlaced", { orderId: order.getId() });
     } else {

--- a/src/app/order/PendingOrders.tsx
+++ b/src/app/order/PendingOrders.tsx
@@ -228,33 +228,24 @@ const PendingOrders = ({ navigation }: any) => {
       {selectedOrder && (
         <Modal animationType="none" transparent={true}>
           <View className="flex-1 justify-center items-center bg-opacity-100">
-            <View className="bg-white border-2 border-gray-500 p-5 items-start justify-start shadow-lg w-[300] h-[180] rounded-lg relative">
-              <TouchableOpacity
-                testID="close-card-button"
-                onPress={() => handleCloseCard()}
-                className="absolute right-5 top-5 "
-              >
-                <Image
-                  source={require("../../../assets/icons/x_icon.png")}
-                  className="w-5 h-5"
-                />
-              </TouchableOpacity>
-              <Text className="text-center font-bold text-xl pt-5 pb-6">
+            <View className="bg-white border-2 border-gray-500 p-5  shadow-lg w-[300] h-[180] rounded-lg">
+              <Text className="text-center font-bold text-xl ">
                 {`Would you like to accept the order for ${t(selectedOrder.getItem().getName() as any)}?`}
               </Text>
-              <Text>{`Distance: ${distance.toFixed(2)} km`}</Text>
-              <View className="flex-row justify-center">
+              <Text className="mt-2 text-lg">{`Trip distance: ${distance.toFixed(2)} km`}</Text>
+              <View className="flex-row justify-between mt-4">
                 <Button
                   text="Accept Order"
                   onPress={handleAcceptOrder}
                   style="primary"
-                  className="shadow-lg w-40"
+                  className="shadow-lg w-36"
                 />
                 <Button
                   text="No"
                   onPress={handleCloseCard}
-                  style="tertiary"
-                  className="shadow-lg w-40"
+                  style="primary"
+                  className="shadow-lg bg-red-400 w-36"
+                  testID="close-card-button"
                 />
               </View>
             </View>

--- a/src/app/order/PendingOrders.tsx
+++ b/src/app/order/PendingOrders.tsx
@@ -187,7 +187,7 @@ const PendingOrders = ({ navigation }: any) => {
         />
       )}
       <FlatList
-        className="mt-4 min-h-full mb-6"
+        className="mt-4 max-h-[90%]"
         data={orderListFiltered}
         renderItem={({ item }) => (
           <OrderCard

--- a/src/app/order/PendingOrders.tsx
+++ b/src/app/order/PendingOrders.tsx
@@ -12,10 +12,8 @@ import { Button } from "../../ui/Button";
 import {
   getDistanceOpToUser,
   Order,
-  orderConverter,
   OrderStatus,
   sortOrders,
-  OrderLocation,
 } from "../../types/Order";
 import { Item } from "../../types/Item";
 import TriangleBackground from "../../components/TriangleBackground";
@@ -25,13 +23,7 @@ import { formatDate } from "../../components/cards/OrderCard";
 import { Picker } from "@react-native-picker/picker";
 import { TextField } from "../../ui/TextField";
 import { useTranslation } from "react-i18next";
-import {
-  firestore,
-  collection,
-  onSnapshot,
-  query,
-  where,
-} from "../../services/Firebase";
+import { firestore, collection, onSnapshot } from "../../services/Firebase";
 
 // Import the useLocation hook
 import useLocation from "../../app/maps/hooks/useLocation";

--- a/src/app/order/PendingOrders.tsx
+++ b/src/app/order/PendingOrders.tsx
@@ -187,7 +187,7 @@ const PendingOrders = ({ navigation }: any) => {
         />
       )}
       <FlatList
-        className="mt-4 max-h-[90%]"
+        className="mt-4 max-h-[90%] min-h-[90%]"
         data={orderListFiltered}
         renderItem={({ item }) => (
           <OrderCard

--- a/src/components/Knaight.tsx
+++ b/src/components/Knaight.tsx
@@ -4,11 +4,12 @@ import {
   View,
   Text,
   StyleSheet,
-  Button,
   TextInput,
   ActivityIndicator,
 } from "react-native";
 import OpenAI from "openai";
+import { TextField } from "../ui/TextField";
+import { Button } from "../ui/Button";
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -19,13 +20,19 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 10,
     backgroundColor: "#fff",
+    //marginBottom: 0,
   },
   userMessage: {
     alignSelf: "flex-end",
-    backgroundColor: "#0044ee",
+    backgroundColor: "#48A6C9",
     borderRadius: 5,
     padding: 10,
     marginVertical: 5,
+    marginLeft: "15%",
+  },
+  userMessageText: {
+    color: "#fff", // White text color
+    fontSize: 16,
   },
   botMessage: {
     alignSelf: "flex-start",
@@ -33,11 +40,16 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     padding: 10,
     marginVertical: 5,
+    marginRight: "15%",
+  },
+  botMessageText: {
+    color: "#000", // Black text color
+    fontSize: 16,
   },
   inputContainer: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 20,
+    marginBottom: 12,
   },
   input: {
     flex: 1,
@@ -122,7 +134,15 @@ const ChatScreen = () => {
               item.sender === "user" ? styles.userMessage : styles.botMessage
             }
           >
-            <Text>{item.text}</Text>
+            <Text
+              style={
+                item.sender === "user"
+                  ? styles.userMessageText
+                  : styles.botMessageText
+              }
+            >
+              {item.text}
+            </Text>
           </View>
         )}
       />
@@ -133,13 +153,20 @@ const ChatScreen = () => {
         />
       )}
       <View style={styles.inputContainer}>
-        <TextInput
-          style={styles.input}
+        <TextField
+          //style={styles.input}
+          className="max-w-[70%] mr-3"
           value={input}
           onChangeText={setInput}
+          type="text"
           placeholder="Type a message..."
         />
-        <Button title="Send" onPress={handleSend} />
+        <Button
+          className="max-w-[25%]"
+          text="Send"
+          onPress={handleSend}
+          style="primary"
+        />
       </View>
     </View>
   );

--- a/src/components/Knaight.tsx
+++ b/src/components/Knaight.tsx
@@ -79,12 +79,7 @@ const ChatScreen = () => {
   const flatListRef = useRef<FlatList>(null);
 
   const scrollToBottom = () => {
-    if (flatListRef.current) {
-      setTimeout(
-        () => flatListRef.current.scrollToEnd({ animated: true }),
-        100
-      );
-    }
+    flatListRef.current?.scrollToEnd({ animated: true });
   };
 
   useEffect(() => {

--- a/src/components/Knaight.tsx
+++ b/src/components/Knaight.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import {
   FlatList,
   View,
@@ -49,7 +49,8 @@ const styles = StyleSheet.create({
   inputContainer: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 12,
+    padding: 0,
+    marginTop: 10,
   },
   input: {
     flex: 1,
@@ -75,6 +76,20 @@ const ChatScreen = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const flatListRef = useRef<FlatList>(null);
+
+  const scrollToBottom = () => {
+    if (flatListRef.current) {
+      setTimeout(
+        () => flatListRef.current.scrollToEnd({ animated: true }),
+        100
+      );
+    }
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
 
   const handleSend = async () => {
     if (!input.trim()) return;
@@ -125,6 +140,8 @@ const ChatScreen = () => {
   return (
     <View style={styles.container}>
       <FlatList
+        className="max-h-[91%]"
+        ref={flatListRef}
         testID="messages-list"
         data={messages}
         keyExtractor={(item) => item.id}
@@ -145,6 +162,8 @@ const ChatScreen = () => {
             </Text>
           </View>
         )}
+        onContentSizeChange={scrollToBottom}
+        onLayout={scrollToBottom}
       />
       {loading && (
         <ActivityIndicator

--- a/src/components/Knaight.tsx
+++ b/src/components/Knaight.tsx
@@ -174,12 +174,14 @@ const ChatScreen = () => {
           onChangeText={setInput}
           type="text"
           placeholder="Type a message..."
+          testID="message-input"
         />
         <Button
           className="max-w-[25%]"
           text="Send"
           onPress={handleSend}
           style="primary"
+          testID="send-button"
         />
       </View>
     </View>

--- a/src/components/SharedMap.tsx
+++ b/src/components/SharedMap.tsx
@@ -56,7 +56,7 @@ const SharedMap: React.FC<SharedMapProps> = ({
 
       <Button
         testID="my-location-button"
-        className="absolute top-[60px] right-[30px] w-16 h-16"
+        className="absolute top-[60px] right-[30px] w-16 h-16 shadow-md bg-white"
         onPress={toggleAutoCenter}
         style="secondary"
       >
@@ -64,7 +64,7 @@ const SharedMap: React.FC<SharedMapProps> = ({
       </Button>
       <Button
         testID="user-drawer-button"
-        className="absolute top-[60px] left-[30px] w-16 h-16"
+        className="absolute top-[60px] left-[30px] w-16 h-16 shadow-md bg-white"
         onPress={() => {
           navigation.toggleDrawer({
             latitude: currentRegion.latitude,
@@ -78,7 +78,7 @@ const SharedMap: React.FC<SharedMapProps> = ({
       {mapType === "user" && (
         <Button
           testID="order-button"
-          className="absolute bottom-[40px] right-[30px] w-[100px] h-16"
+          className="absolute bottom-[40px] right-[30px] w-[100px] h-16 shadow-md"
           onPress={() => {
             navigation.navigate("OrderMenu", {
               latitude: currentRegion.latitude,

--- a/src/services/FirestoreManager.ts
+++ b/src/services/FirestoreManager.ts
@@ -92,6 +92,7 @@ export default class FirestoreManager {
    * @returns - The order with the specified id
    */
   async readData(collection: string, id: string): Promise<any | null> {
+    this.checkStaleOrders();
     const docRef = doc(firestore, collection, id).withConverter(
       this.converterDictionary[collection]
     );
@@ -117,6 +118,7 @@ export default class FirestoreManager {
    * @returns - An array of orders that match the query
    */
   async queryOrder(field: string, data: string): Promise<Order[] | null> {
+    this.checkStaleOrders();
     const validFields = ["userId", "status", "item.name", "operatorId"];
     if (validFields.includes(field)) {
       var orders: Order[] = [];
@@ -233,6 +235,45 @@ export default class FirestoreManager {
       }
     } catch (e) {
       console.error("Error updating document in the database: ", e);
+    }
+  }
+  /**
+   * Method to check for stale orders in the database and delete them if they have been pending for more than 6 hours.
+   *
+   * @returns {Promise<void>} - A promise that resolves when the operation is complete.
+   */
+  async checkStaleOrders(): Promise<void> {
+    const sixHoursInMilliseconds = 6 * 60 * 60 * 1000;
+    const now = Date.now();
+    try {
+      const q = query(
+        collection(firestore, "orders"),
+        where("status", "==", OrderStatus.Pending)
+      ).withConverter(orderConverter);
+      const querySnapshot = await getDocs(q);
+      // print the "age" of each order
+      querySnapshot.forEach((docSnapshot) => {
+        const order = docSnapshot.data();
+        const orderDate = order.getOrderDate().getTime();
+        console.log(`Order ${order.getId()} is ${now - orderDate} ms old.`);
+      });
+      const staleOrders: Order[] = [];
+      querySnapshot.forEach((docSnapshot) => {
+        const order = docSnapshot.data();
+        const orderDate = order.getOrderDate().getTime();
+        if (now - orderDate > sixHoursInMilliseconds) {
+          staleOrders.push(order);
+        }
+      });
+
+      console.log(`Found ${staleOrders.length} stale orders.`);
+
+      for (const order of staleOrders) {
+        await this.deleteData("orders", order.getId());
+        console.log(`Deleted stale order with ID: ${order.getId()}`);
+      }
+    } catch (error) {
+      console.error("Error while checking for stale orders: ", error);
     }
   }
 }

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -122,19 +122,33 @@ class Order {
   getOpName(): string {
     return this.operatorName;
   }
+}
 
-  // toDict(): { [key: string]: string } {
-  //   return {
-  //     id: this.id,
-  //     userId: this.userId,
-  //     operatorId: this.operatorId,
-  //     item: JSON.stringify(this.item.toDict()),
-  //     orderDate: this.orderDate.toString(),
-  //     status: this.status,
-  //     deliveryDate: this.deliveryDate.toString(),
-  //     location: JSON.stringify(this.usrLocation),
-  //   };
-  // }
+export function getDistanceOpToUser(
+  opLoc: OrderLocation,
+  userLoc: OrderLocation
+) {
+  // based on this https://stackoverflow.com/questions/27928/calculate-distance-between-two-latitude-longitude-points-haversine-formula
+  const lat1 = userLoc.latitude;
+  const lon1 = userLoc.longitude;
+  const lat2 = opLoc.latitude;
+  const lon2 = opLoc.longitude;
+  var R = 6371; // Radius of the earth in km
+  var dLat = deg2rad(lat2 - lat1); // deg2rad below
+  var dLon = deg2rad(lon2 - lon1);
+  var a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(deg2rad(lat1)) *
+      Math.cos(deg2rad(lat2)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  var d = R * c; // Distance in km
+  return d;
+}
+
+function deg2rad(deg: number) {
+  return deg * (Math.PI / 180);
 }
 
 const orderConverter = {

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -67,7 +67,7 @@ class Order {
         ), // in case of timeout error is thrown, and we go to catch block
       ])) as Response;
       const data = await response.json();
-      this.usrLocName = data.name;
+      this.usrLocName = data.name || this.usrLocName;
     } catch {
       console.error(
         "Failed to fetch location name with Nominatim API. Request timed out"

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -21,13 +21,17 @@ export function Button({
   onPress: () => void;
   testID?: string;
   className?: string;
-  style: "primary" | "secondary";
+  style: "primary" | "secondary" | "tertiary";
 }) {
   return (
     <TouchableOpacity
       className={twMerge(
         "w-full rounded-full flex-row items-center justify-center h-12 gap-2",
-        style == "primary" ? "bg-primary-400" : "bg-gray-200",
+        style == "primary"
+          ? "bg-primary-400"
+          : style == "secondary"
+            ? "bg-gray-100"
+            : "bg-primary-500",
         className
       )}
       onPress={onPress}
@@ -38,7 +42,11 @@ export function Button({
         <Text
           className={twMerge(
             "text-lg text-center",
-            style == "primary" ? "text-white font-bold" : "text-black"
+            style == "primary"
+              ? "text-white font-bold"
+              : style == "secondary"
+                ? "text-black"
+                : "text-white font-bold"
           )}
         >
           {text}

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -21,17 +21,13 @@ export function Button({
   onPress: () => void;
   testID?: string;
   className?: string;
-  style: "primary" | "secondary" | "tertiary";
+  style: "primary" | "secondary";
 }) {
   return (
     <TouchableOpacity
       className={twMerge(
         "w-full rounded-full flex-row items-center justify-center h-12 gap-2",
-        style == "primary"
-          ? "bg-primary-400"
-          : style == "secondary"
-            ? "bg-gray-100"
-            : "bg-primary-500",
+        style == "primary" ? "bg-primary-400" : "bg-gray-200",
         className
       )}
       onPress={onPress}
@@ -42,11 +38,7 @@ export function Button({
         <Text
           className={twMerge(
             "text-lg text-center",
-            style == "primary"
-              ? "text-white font-bold"
-              : style == "secondary"
-                ? "text-black"
-                : "text-white font-bold"
+            style == "primary" ? "text-white font-bold" : "text-black"
           )}
         >
           {text}


### PR DESCRIPTION
### App.tsx
With the introduction of checking the user role before redirecting to "OperatorDrawer" vs. "UserDrawer" in App.tsx, we lost persistent authentication in offline case as getUser() required internet connection and there was no timeout. We now use AsyncStorage to store the latest role associated to that user, this AsyncStorage is only used after the call to getUser() times out.
### OrderHistory.tsx
With some updates to navigation headings from last weekend the FlatList was once again having the issue where the user could not scroll to see the OrderCards at the end. Has been updated by using a fixed % height.
### PendingOrders.tsx
Same issue as with OrderHistory FlatList got resolved.
We now fetch the operators location when he clicks on an OrderCard and appropiately compute the distance between him and where the buyer is situated.
Updated look, got rid of the "X" button.
![image](https://github.com/KnightDrone/Knight/assets/93383002/020ef2f6-fe81-4d1f-ac8c-692ca32ecd7e)
### KnAIght.tsx
FlatList displaying messages is now scrolled down whenever a new message is added.
Updated the UI to match with the rest of the app
![image](https://github.com/KnightDrone/Knight/assets/93383002/4bc292c5-560d-486f-beb0-ea115a5d9ef5)
### SharedMap.tsx
Updated styling on buttons to help with visibility
### FirestoreManager.ts
Defined checkStaleOrders() which queries Firestore and deletes all Orders which have been in Pending status for more than 6 hours.
This method is called only when calling readData() and queryOrder()
### Order.ts
Defined function to compute distance
Removed old toDict() comment
